### PR TITLE
Add in split support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: ruby
+bundler_args: --without development

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,11 @@ gemspec
 
 gem "rake"
 gem "rdoc", :require => false
-gem "debugger"
+
+group :test do
+  gem 'rspec'
+end
+
+group :development do
+  gem "byebug"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    columnize (0.3.6)
-    debugger (1.6.3)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.2.4)
+    byebug (3.5.1)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+      slop (~> 3.6)
+    columnize (0.8.9)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.2.4)
     diff-lcs (1.2.5)
     json (1.8.1)
     rake (10.1.0)
@@ -26,13 +25,14 @@ GEM
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
+    slop (3.6.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  debugger
+  byebug
   qif!
   rake
   rdoc
-  rspec (>= 2.5.0)
+  rspec

--- a/lib/qif/amount_parser.rb
+++ b/lib/qif/amount_parser.rb
@@ -1,0 +1,6 @@
+module AmountParser
+  def self.parse(amount)
+    warn "= amounts are unsupported" if amount =~ /^=/
+    amount.gsub(/,/, '').gsub(/^=/, '').to_f
+  end
+end

--- a/lib/qif/transaction.rb
+++ b/lib/qif/transaction.rb
@@ -12,6 +12,7 @@ module Qif
       :memo           => {"M" => "Memo"                                                              },
       :adress         => {"A" => "Address (up to five lines; the sixth line is an optional message)" },
       :category       => {"L" => "Category (Category/Subcategory/Transfer/Class)"                    },
+      # do we still need these? we have splits now
       :split_category => {"S" => "Category in split (Category/Transfer/Class)"                       },
       :split_memo     => {"E" => "Memo in split"                                                     },
       :split_amount   => {"$" => "Dollar amount of split"                                            },
@@ -24,14 +25,12 @@ module Qif
     }
     SUPPORTED_FIELDS.keys.each{|s| attr_accessor s}
 
-    def self.read(record) #::nodoc
-      return nil unless record['D'].respond_to?(:strftime)
-      SUPPORTED_FIELDS.each{|k,v| record[k] = record.delete(v.keys.first)}
-      record.reject{|k,v| v.nil?}.each{|k,v| record[k] = record[k].to_f if k.to_s.include? "amount"}
-      Transaction.new record
-    end
+    attr_reader :splits
+    alias :address :adress
+    alias :address= :adress=
 
     def initialize(attributes = {})
+      @splits = []
       deprecate_attributes!(attributes)
       SUPPORTED_FIELDS.keys.each{|s| instance_variable_set("@#{s.to_s}", attributes[s])}
     end

--- a/lib/qif/transaction/builder.rb
+++ b/lib/qif/transaction/builder.rb
@@ -1,0 +1,48 @@
+require_relative "split/builder"
+require_relative "builderable"
+require_relative "../amount_parser"
+
+class Qif::Transaction::Builder
+  include Builderable
+
+  def initialize(date_parser = ->(date) { Time.parse(date) })
+    @txn = Qif::Transaction.new
+    @date_parser = date_parser
+    @splits = []
+  end
+
+  set_builder_method :date, :parse_date
+  set_builder_method :amount, ->(amt) { AmountParser.parse(amt) }
+  set_builder_method :status
+  set_builder_method :number
+  set_builder_method :payee
+  set_builder_method :memo
+  set_builder_method :category
+
+  def set_adress(address)
+    @txn.address = @txn.address ? @txn.address += "\n#{address}" : address
+    self
+  end
+
+  alias :set_address :set_adress
+
+  def add_split(split)
+    Qif::Transaction::Split::Builder.new(self).tap do |split_builder|
+      @splits << split_builder
+      split_builder.set_split_category(split)
+    end
+  end
+
+  def build
+    @splits.each do |split_builder|
+      @txn.splits << split_builder.build_split
+    end
+    @txn
+  end
+
+  private
+
+  def parse_date(date)
+    @date_parser.call(date)
+  end
+end

--- a/lib/qif/transaction/builderable.rb
+++ b/lib/qif/transaction/builderable.rb
@@ -1,0 +1,27 @@
+module Builderable
+  def self.included(base)
+    base.extend ClassMethods
+  end
+
+  module ClassMethods
+    def builder_options(options)
+      @options = options
+    end
+
+    def set_builder_method(attribute, massager = nil)
+      options = @options || {}
+      method_name = ["set", options[:prefix], attribute].compact.join("_")
+      define_method(method_name) do |new_value|
+        unless massager.nil?
+          if massager.kind_of?(Symbol)
+            new_value = self.send(massager, new_value)
+          else
+            new_value = massager.call(new_value)
+          end
+        end
+        @txn.send("#{attribute}=", new_value)
+        self
+      end
+    end
+  end
+end

--- a/lib/qif/transaction/split.rb
+++ b/lib/qif/transaction/split.rb
@@ -1,0 +1,3 @@
+class Qif::Transaction::Split
+  attr_accessor :memo, :amount, :category
+end

--- a/lib/qif/transaction/split/builder.rb
+++ b/lib/qif/transaction/split/builder.rb
@@ -1,0 +1,28 @@
+require_relative '../builderable'
+require_relative '../split'
+
+class Qif::Transaction::Split::Builder
+  include Builderable
+
+  def initialize(transaction_builder)
+    @transaction_builder = transaction_builder
+    @txn = Qif::Transaction::Split.new
+  end
+
+  def add_split(split_memo)
+    @transaction_builder.add_split(split_memo)
+  end
+
+  builder_options prefix: 'split'
+  set_builder_method :memo
+  set_builder_method :amount, ->(amt) { AmountParser.parse(amt) }
+  set_builder_method :category
+
+  def build_split
+    @txn
+  end
+
+  def method_missing(name, *args, &block)
+    @transaction_builder.send(name, *args, &block)
+  end
+end

--- a/spec/fixtures/splits.qif
+++ b/spec/fixtures/splits.qif
@@ -1,0 +1,20 @@
+!Type:Bank
+D6/1/94
+T-1,000.00
+CX
+N1005
+PBank Of Mortgage
+MMemo
+L[linda]
+S[steve]
+ECash
+$-253.64
+SMort Int
+$=746.36
+^
+D6/2/94
+Scategory 1
+$23
+T75.00
+PDeposit
+^

--- a/spec/lib/reader_spec.rb
+++ b/spec/lib/reader_spec.rb
@@ -107,4 +107,42 @@ describe Qif::Reader do
     @instance = Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'), 'mm/dd/yyyy')
     @instance.size.should == 2
   end
+
+  context 'when reading splits' do
+    let(:reader) { Qif::Reader.new(open('spec/fixtures/splits.qif'), 'd/m/yyyy') }
+
+    context 'the first transaction' do
+      let (:transaction) { reader.transactions[0] }
+
+      it 'should have the correct number of splits' do
+        expect(transaction.splits.size).to eq(2)
+      end
+
+      context 'the first split' do
+        let (:split) { transaction.splits.first }
+
+        it { expect(split.category).to eq("[steve]") }
+        it { expect(split.memo).to eq("Cash") }
+        it { expect(split.amount).to eq(-253.64)}
+      end
+
+      context 'the second split' do
+        let (:split) { transaction.splits[1] }
+
+        it { expect(split.category).to eq("Mort Int") }
+        it { expect(split.amount).to eq(746.36) }
+      end
+
+    end
+
+    context "when the transaction has splits first" do
+      let(:transaction) { reader.transactions[1] }
+
+      it 'should correctly add the amount to the transaction' do
+        expect(transaction.amount).to eq(75)
+      end
+
+      it { expect(transaction.splits.first.amount).to eq(23) }
+    end
+  end
 end

--- a/spec/lib/transaction_builder_spec.rb
+++ b/spec/lib/transaction_builder_spec.rb
@@ -1,0 +1,122 @@
+require 'spec_helper'
+require 'qif/transaction/builder'
+require 'qif/transaction/split/builder'
+
+describe Qif::Transaction::Builder do
+  let(:builder) { Qif::Transaction::Builder.new }
+  def split_builder
+    double(Qif::Transaction::Split::Builder).tap do |b|
+      allow(b).to receive(:set_split_category).and_return(b)
+    end
+  end
+  def do_build
+    builder.build
+  end
+
+  context '#build' do
+    it 'should return a transaction object' do
+      expect(builder.build).to be_kind_of(Qif::Transaction)
+    end
+
+    context 'with splits' do
+      it 'should call build_split on each of the splits' do
+        sb1 = split_builder
+        sb2 = split_builder
+        allow(Qif::Transaction::Split::Builder).to receive(:new).and_return(sb1, sb2)
+        expect(sb1).to receive(:build_split).ordered
+        expect(sb2).to receive(:build_split).ordered
+        builder.add_split("a")
+        builder.add_split("b")
+        builder.build
+      end
+
+      it 'should add the splits to the transaction' do
+        builder.add_split("a")
+        builder.add_split("b")
+        expect(builder.build.splits.count).to eq(2)
+      end
+    end
+  end
+
+ context '#set_date' do
+    it_should_behave_like 'builder method', :date, '1994-06-01', :set_date, Time.mktime(1994, 6, 1)
+    it 'should use a given date parser' do
+      b = Qif::Transaction::Builder.new(->(date) { date })
+      b.set_date('1994')
+      expect(b.build.date).to eq('1994')
+    end
+  end
+
+  context '#set_amount' do
+    it_should_behave_like 'builder method', :amount, '-1000.00', :set_amount, -1000.0
+    it 'should parse commas out of the amount' do
+      builder.set_amount('1,000,000')
+      expect(builder.build.amount).to eq(1_000_000)
+    end
+  end
+
+  context '#set_status' do
+    it_should_behave_like 'builder method', :status, 'X', :set_status, 'X'
+  end
+
+  context '#set_number' do
+    it_should_behave_like 'builder method', :number, '1005', :set_number, '1005'
+  end
+
+  context '#set_payee' do
+    it_should_behave_like 'builder method', :payee, 'Bank of Mortgage', :set_payee, 'Bank of Mortgage'
+  end
+
+  context '#set_memo' do
+    it_should_behave_like 'builder method', :memo, 'Some stuff that happened', :set_memo, 'Some stuff that happened'
+  end
+
+  context '#set_category' do
+    it_should_behave_like 'builder method', :category, 'Fishing', :set_category, 'Fishing'
+  end
+
+  context '#set_address' do
+    address = <<-EOA
+      P.O. Box 1234
+      Somewhereton
+      12345
+    EOA
+    
+    it_should_behave_like 'builder method', :adress, address, :set_adress, address
+
+    context 'when called consecutively' do
+      it "should append to the address" do
+        builder
+          .set_address("Line 1")
+          .set_address("Line 2")
+        expect(do_build.address).to eq("Line 1\nLine 2")
+      end
+    end
+  end
+
+  context "#add_split" do
+    it 'should create a new split builder' do
+      expect(Qif::Transaction::Split::Builder).to receive(:new).with(builder).and_return(split_builder)
+      builder.add_split("aaa")
+    end
+
+    it 'should set the category on the split builder' do
+      sb = split_builder
+      allow(Qif::Transaction::Split::Builder).to receive(:new).and_return(sb)
+      expect(sb).to receive(:set_split_category).with('aaaa')
+      builder.add_split('aaaa')
+    end
+
+    it "should return a split builder" do
+      expect(builder.add_split('aaaa')).to be_kind_of(Qif::Transaction::Split::Builder)
+    end
+
+    context "when called multiple times" do
+      it "should return multiple different builders" do
+        sb1 = builder.add_split("aaaa")
+        expect(builder.add_split("bbbb")).to_not eq(sb1)
+      end
+    end
+  end
+
+end

--- a/spec/lib/transaction_spec.rb
+++ b/spec/lib/transaction_spec.rb
@@ -1,46 +1,6 @@
 require 'spec_helper'
 
 describe Qif::Transaction do
-  describe '::read' do
-    it 'should return a new transaction with all attributes set' do
-      t = Qif::Transaction.read(
-        'D' => Time.parse('1994-06-01'),
-        'T' => '-1000.00'.to_f,
-        'C' => 'X',
-        'N' => '1005',
-        'P' => 'Bank Of Mortgage',
-        'M' => 'aMemo',
-        'L' => 'aCategory',
-# TODO Support correctly splits with an array of hash
-#        'S' => '[linda]
-#Mort Int',
-#        'E' => 'Cash',
-#        '$' => '-253.64
-#=746.36',
-        'A' => 'P.O. Box 27027
-Tucson, AZ
-85726',
-        '^' => nil
-      )
-
-      t.should be_a(Qif::Transaction)
-      t.date.should == Time.mktime(1994,6,1)
-      t.amount.should == -1000.00
-      t.status.should == 'X'
-      t.number.should == '1005'
-      t.payee.should == 'Bank Of Mortgage'
-      t.memo.should == 'aMemo'
-      t.category.should == 'aCategory'
-      t.adress.should == 'P.O. Box 27027
-Tucson, AZ
-85726'
-    end
-    
-    it 'should return nil if the date does not respond to strftime' do
-      Qif::Transaction.read('D' => 'hello').should be_nil
-    end
-  end
-  
   describe '#to_s' do
     before do
       @instance = Qif::Transaction.new(

--- a/spec/lib/transaction_split_builder_spec.rb
+++ b/spec/lib/transaction_split_builder_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'qif/transaction/split/builder'
+
+describe Qif::Transaction::Split::Builder do
+  let(:parent) { double(Qif::Transaction::Builder) }
+  let(:builder) { Qif::Transaction::Split::Builder.new(parent) }
+  def do_build
+    builder.build_split
+  end
+
+  context '#add_split' do
+    it 'should call add_split on the parent' do
+      expect(parent).to receive(:add_split).with("12345")
+      described_class.new(parent).add_split("12345")
+    end
+
+    it 'should return the new split builder' do
+      new_builder = double("split-builder")
+      allow(parent).to receive(:add_split).and_return(new_builder)
+      expect(described_class.new(parent).add_split(anything)).to eq(new_builder)
+    end
+  end
+
+  context '#set_memo' do
+    it_should_behave_like "builder method", :memo, 'Split', :set_split_memo
+  end
+
+  context '#set_amount' do
+    it_should_behave_like "builder method", :amount, '-10,000', :set_split_amount, -10000
+  end
+
+  context '#set_category' do
+    it_should_behave_like 'builder method', :category, '[Cash]', :set_split_category
+  end
+
+  context "when receiving an unknown message" do
+    it "should pass the message to the parent" do
+      expect(parent).to receive(:set_date).with('2012-12-31')
+      builder.set_date('2012-12-31')
+    end
+
+    it 'should return the result of the message' do
+      allow(parent).to receive(:set_date).and_return(parent)
+      expect(builder.set_date(anything)).to eq(parent)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
 require File.dirname(__FILE__) + '/../lib/qif'
+
+require_relative "support/shared/builder_method"

--- a/spec/support/shared/builder_method.rb
+++ b/spec/support/shared/builder_method.rb
@@ -1,0 +1,14 @@
+shared_context 'builder method' do |attribute, input, method = nil, expected = nil|
+  expected = input if expected.nil?
+  method = "set_#{attribute}" if method.nil?
+
+  it 'and set the #{attribute} on the transaction' do
+    builder.send(method, input)
+    expect(do_build.send(attribute)).to eq(expected)
+  end
+
+  it 'and return the builder' do
+    expect(builder.send(method, input)).to be_kind_of described_class
+  end
+end
+


### PR DESCRIPTION
This change adds in support for reading splits. Now each transaction has an array of splits, each with a category, memo and amount.

In order to do this this change moves the parsing to use a builder pattern. This is so when we get to the splits the `Qif::Reader.read_transaction` method can transparently just call `add_split` without having to keep track of whether it should start a new split or not. It also means we can encapsulate the building process and perform any special handling in the builder if we so choose (e.g. addresses can have multiple lines, but it doesn't make sense for amounts or categories to have multiple lines).

Because we now have builders, it made sense to remove `Qif::Transaction.read`. It shouldn't be the responsibility of the transaction to do reading or building, not now we have things that have encapsulated the responsibilities elsewhere.
