### PR TITLE
Update example in README to use non-deprecated fields

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,7 +17,7 @@
   require 'qif'
   qif = Qif::Reader.new(open('/path/to/file.qif'))
   qif.each do |transaction|
-    puts [transaction.name, transaction.description, transaction.amount].join(", ")
+    puts [transaction.payee, transaction.amount].join(", ")
   end
 
 === CSV conversion example


### PR DESCRIPTION
It looks like the current example uses fields that aren't in `SUPPORTED_FIELDS` so generates an error when run.