### PR TITLE
Add support for parsing accounts

### DIFF
--- a/lib/qif/account.rb
+++ b/lib/qif/account.rb
@@ -1,0 +1,43 @@
+require 'qif/date_format'
+
+module Qif
+  # The Qif::Account class represents an account in a qif file.
+  class Account
+    SUPPORTED_FIELDS = {
+      :name           => {"N" => "Name"                                                              },
+      :type           => {"T" => "Type"                                                              },
+      :description    => {"D"=> "Description"                                                        },
+      :limit          => {"L" => "Credit Limit (if applicable)"                                      },
+      :balance_date   => {"/" => "Statement balance date"                                            },
+      :balance        => {"\$" => "Statement balance",                                                },
+      :end            => {"^" => "End of entry"                                                      }
+    }
+
+    SUPPORTED_FIELDS.keys.each{|s| attr_accessor s}
+
+    def initialize(attributes = {})
+      SUPPORTED_FIELDS.keys.each{|s| instance_variable_set("@#{s.to_s}", attributes[s])}
+    end
+
+    # Returns a representation of the account as it
+    # would appear in a qif file.
+    def to_s(format = 'dd/mm/yyyy')
+      SUPPORTED_FIELDS.collect do |k,v|
+        next unless current = instance_variable_get("@#{k}")
+        field = v.keys.first
+        case current.class.to_s
+        when "Time", "Date", "DateTime"
+          "#{field}#{DateFormat.new(format).format(current)}"
+        when "Float"
+          "#{field}#{'%.2f'%current}"
+        when "String"
+          current.split("\n").collect {|x| "#{field}#{x}" }
+        else
+          "#{field}#{current}"
+        end
+      end.flatten.compact.unshift('!Account').join("\n")
+    end
+
+    private
+  end
+end

--- a/lib/qif/account/builder.rb
+++ b/lib/qif/account/builder.rb
@@ -1,0 +1,29 @@
+require_relative "../transaction/builderable"
+require_relative "../amount_parser"
+
+class Qif::Account::Builder
+  include Builderable
+
+  def initialize(date_parser = ->(date) { Time.parse(date) })
+    @txn = Qif::Account.new
+    @date_parser = date_parser
+    @splits = []
+  end
+
+  set_builder_method :name
+  set_builder_method :type
+  set_builder_method :description
+  set_builder_method :limit, ->(amt) { AmountParser.parse(amt) }
+  set_builder_method :balance_date, :parse_date
+  set_builder_method :balance, ->(amt) { AmountParser.parse(amt) }
+
+  def build
+    @txn
+  end
+
+  private
+
+  def parse_date(date)
+    @date_parser.call(date)
+  end
+end

--- a/spec/fixtures/quicken_non_investement_account_with_account_block.qif
+++ b/spec/fixtures/quicken_non_investement_account_with_account_block.qif
@@ -1,0 +1,35 @@
+!Type:Bank
+D6/1/94
+T-1,000.00
+CX
+N1005
+PBank Of Mortgage
+MMemo
+L[linda]
+S[linda]
+ECash
+$-253.64
+SMort Int
+$=746.36
+^
+D6/2/94
+T75.00
+PDeposit
+^
+D6/3/94
+T-10.00
+PAnthony Hopkins
+MFilm
+LEntertain
+AP.O. Box 27027
+ATucson, AZ
+A85726
+A
+A
+A
+^
+!Account
+NNice Account
+TBank
+DThis is a fine account
+^

--- a/spec/lib/reader_spec.rb
+++ b/spec/lib/reader_spec.rb
@@ -145,4 +145,15 @@ describe Qif::Reader do
       it { expect(transaction.splits.first.amount).to eq(23) }
     end
   end
+
+  context "reading account blocks" do
+    it 'should parse the account block' do
+      @instance = Qif::Reader.new(open('spec/fixtures/quicken_non_investement_account_with_account_block.qif'))
+      account = @instance.transactions.last
+      expect(account).to be_a(Qif::Account)
+      expect(account.name).to eq("Nice Account")
+      expect(account.type).to eq("Bank")
+      expect(account.description).to eq("This is a fine account")
+    end
+  end
 end


### PR DESCRIPTION
This adds support for parsing the !Account block in a QIF file. 

Because the block could occur anywhere in the file (in the files I am working with they are at the very end) I made it so read_record would return it when found.

If it is undesirable that a record is no longer always a transaction, instead the account block could be looked for when the file is open (similar to the headers) but this could be very inefficient if the whole file has to be scanned before it is found.
