### PR TITLE
Add missing output of splits

### DIFF
--- a/lib/qif/transaction.rb
+++ b/lib/qif/transaction.rb
@@ -51,7 +51,7 @@ module Qif
         else
           "#{field}#{current}"
         end
-      end.flatten.compact.join("\n")
+      end.concat(@splits.collect{|s| s.to_s}).flatten.compact.join("\n")
     end
 
     private

--- a/lib/qif/transaction/split.rb
+++ b/lib/qif/transaction/split.rb
@@ -1,3 +1,26 @@
 class Qif::Transaction::Split
+  SUPPORTED_FIELDS = {
+    :category => {"S" => "Category in split (Category/Transfer/Class)" },
+    :memo     => {"E" => "Memo in split"                               },
+    :amount   => {"$" => "Dollar amount of split"                      },
+  }
+
   attr_accessor :memo, :amount, :category
+
+  # Returns a representation of the split as it
+  # would appear in a qif file.
+  def to_s()
+    SUPPORTED_FIELDS.collect do |k,v|
+      next unless current = instance_variable_get("@#{k}")
+      field = v.keys.first
+      case current.class.to_s
+      when "Float"
+        "#{field}#{'%.2f'%current}"
+      when "String"
+        current.split("\n").collect {|x| "#{field}#{x}" }
+      else
+        "#{field}#{current}"
+      end
+    end.flatten.compact.join("\n")
+  end
 end


### PR DESCRIPTION
In the custom CSV-to-QIF script I was writing, I noticed that the splits I added were not making their way to the QIF. It appears that output of the @split array was not implemented, so I added it, matching the transaction output (read: cut-n-paste job).