### PR TITLE
Request support of "m'd'yy" date format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gem "rake"
 gem "rdoc", :require => false
 gem "rspec"
 
-group :development do
+group :development, :test do
   gem "byebug"
 end

--- a/lib/qif/amount_parser.rb
+++ b/lib/qif/amount_parser.rb
@@ -1,6 +1,6 @@
 module AmountParser
   def self.parse(amount)
-    warn "= amounts are unsupported" if amount =~ /^=/
+    warn "= amounts are unsupported" if amount =~ /^=/ && $VERBOSE
     amount.gsub(/,/, '').gsub(/^=/, '').to_f
   end
 end

--- a/lib/qif/date_format.rb
+++ b/lib/qif/date_format.rb
@@ -2,7 +2,6 @@ require 'time'
 
 module Qif
   class DateFormat
-    attr_reader :format
 
     SUPPORTED_DATEFORMAT = {
       "dd/mm/yyyy"  => "%d/%m/%Y",

--- a/lib/qif/date_format.rb
+++ b/lib/qif/date_format.rb
@@ -23,6 +23,8 @@ module Qif
       "m/dd/yy"     => "%m/%d/%y",
       "mm/d/yy"     => "%m/%d/%y",
       "m/d/yy"      => "%m/%d/%y",
+
+      "m'd'yy"      => "%m'%d'%y",
     }
 
     def initialize(format = 'dd/mm/yyyy')

--- a/lib/qif/reader.rb
+++ b/lib/qif/reader.rb
@@ -18,7 +18,7 @@ module Qif
     include Enumerable
 
     attr_reader :index
-  
+
     SUPPORTED_ACCOUNTS = {
       "!Type:Bank" => "Bank account transactions",
       "!Type:Cash" => "Cash account transactions",
@@ -33,9 +33,9 @@ module Qif
     # Create a new Qif::Reader object. The data argument must be
     # either an IO object or a String containing the Qif file data.
     #
-    # The optional format argument specifies the date format in the file. 
-    # Giving a format will force it, otherwise the format will guessed 
-    # reading the transactions in the file, this defaults to 'dd/mm/yyyy' 
+    # The optional format argument specifies the date format in the file.
+    # Giving a format will force it, otherwise the format will guessed
+    # reading the transactions in the file, this defaults to 'dd/mm/yyyy'
     # if guessing method fails.
     def initialize(data, format = nil)
       @data = data.respond_to?(:read) ? data : StringIO.new(data.to_s)
@@ -46,7 +46,7 @@ module Qif
       raise(UnknownAccountType, "Unknown account type. Should be one of followings :\n#{SUPPORTED_ACCOUNTS.keys.inspect}") unless SUPPORTED_ACCOUNTS.keys.collect(&:downcase).include? @header.downcase
       reset
     end
-    
+
     # Return an array of Qif::Transaction objects from the Qif file. This
     # method reads the whole file before returning, so it may not be suitable
     # for very large qif files.
@@ -54,7 +54,7 @@ module Qif
       read_all_transactions
       transaction_cache
     end
-  
+
     # Call a block with each Qif::Transaction from the Qif file. This
     # method yields each transaction as it reads the file so it is better
     # to use this than #transactions for large qif files.
@@ -62,14 +62,13 @@ module Qif
     #   reader.each do |transaction|
     #     puts transaction.amount
     #   end
-    def each(&block)    
+    def each(&block)
       reset
-    
+
       while transaction = next_transaction
         yield transaction
       end
     end
-    
 
     def errors
       read_all_transactions
@@ -116,22 +115,22 @@ module Qif
     rescue
       false
     end
-  
+
     def read_all_transactions
       while next_transaction; end
     end
-  
+
     def transaction_cache
       @transaction_cache ||= []
     end
-  
+
     def reset
       @index = -1
     end
-  
+
     def next_transaction
       @index += 1
-    
+
       if transaction = transaction_cache[@index]
         transaction
       else
@@ -157,19 +156,19 @@ module Qif
 
       @header = headers.shift
       @options = headers.map{|h| h.split(':') }.last
-      
+
       unless line =~ /^\^/
         rewind_to @data.lineno - 1
       end
       headers
     end
-  
+
     def read_transaction
       if transaction = read_record
         cache_transaction(transaction)
       end
     end
-  
+
     def cache_transaction(transaction)
       transaction_cache[@index] = transaction unless transaction.is_a?(Exception)
     end

--- a/spec/lib/date_format_spec.rb
+++ b/spec/lib/date_format_spec.rb
@@ -4,16 +4,16 @@ describe Qif::DateFormat do
   it 'should work with 2 digit years in mm/dd/yy format' do
     reader = Qif::DateFormat.new('mm/dd/yy')
     time = reader.parse('09/28/10')
-    time.should == Date.strptime('09/28/10', '%m/%d/%y')
+    expect(time).to eq(Date.strptime('09/28/10', '%m/%d/%y'))
 		time = reader.parse('09/28/94')
-		time.should == Date.strptime('09/28/94', '%m/%d/%y')
+		expect(time).to eq(Date.strptime('09/28/94', '%m/%d/%y'))
   end
 
   it 'should work with 2 digit years in dd/mm/yy format' do
     reader = Qif::DateFormat.new('dd/mm/yy')
     time = reader.parse('28/09/10')
-    time.should == Date.strptime('28/09/10', '%d/%m/%y')
+    expect(time).to eq(Date.strptime('28/09/10', '%d/%m/%y'))
 		time = reader.parse('28/09/94')
-		time.should == Date.strptime('28/09/94', '%d/%m/%y')
+		expect(time).to eq(Date.strptime('28/09/94', '%d/%m/%y'))
   end
 end

--- a/spec/lib/reader_spec.rb
+++ b/spec/lib/reader_spec.rb
@@ -67,40 +67,40 @@ describe Qif::Reader do
 
   describe '#guess_date_format' do
     it 'should guess the date format dd/mm/yyyy' do
-      @instance = Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'))
-      expect(@instance.guess_date_format).to eq('dd/mm/yyyy')
+      instance = Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'))
+      expect(instance.guess_date_format).to eq('dd/mm/yyyy')
     end
 
     it 'should guess the date format mm/dd/yy' do
-      @instance = Qif::Reader.new(open('spec/fixtures/3_records_mmddyy.qif'))
-      expect(@instance.guess_date_format).to eq('mm/dd/yy')
+      instance = Qif::Reader.new(open('spec/fixtures/3_records_mmddyy.qif'))
+      expect(instance.guess_date_format).to eq('mm/dd/yy')
     end
 
     it 'should fall back to best guess if the date are ambiguious' do
-      @instance = Qif::Reader.new(open('spec/fixtures/quicken_non_investement_account.qif'))
-      expect(@instance.guess_date_format).to eq('dd/mm/yy')
+      instance = Qif::Reader.new(open('spec/fixtures/quicken_non_investement_account.qif'))
+      expect(instance.guess_date_format).to eq('dd/mm/yy')
     end
 
     it 'should guess the date format d/m/yy' do
-      @instance = Qif::Reader.new(open('spec/fixtures/3_records_dmyy.qif'))
-      expect(@instance.guess_date_format).to eq('dd/mm/yy')
+      instance = Qif::Reader.new(open('spec/fixtures/3_records_dmyy.qif'))
+      expect(instance.guess_date_format).to eq('dd/mm/yy')
     end
   end
 
   it 'should parse amounts with comma separator too' do
-    @instance = Qif::Reader.new(open('spec/fixtures/3_records_separator.qif'))
-    expect(@instance.size).to eq(3)
-    expect(@instance.collect(&:amount)).to eq([-1010.0, -30020.0, 30.0])
+    instance = Qif::Reader.new(open('spec/fixtures/3_records_separator.qif'))
+    expect(instance.size).to eq(3)
+    expect(instance.collect(&:amount)).to eq([-1010.0, -30020.0, 30.0])
   end
 
   it 'should initialize with an io object' do
-    @instance = Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'))
-    expect(@instance.size).to eq(3)
+    instance = Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'))
+    expect(instance.size).to eq(3)
   end
 
   it 'should initialize with data in a string' do
-    @instance = Qif::Reader.new(File.read('spec/fixtures/3_records_ddmmyyyy.qif'))
-    expect(@instance.size).to eq(3)
+    instance = Qif::Reader.new(File.read('spec/fixtures/3_records_ddmmyyyy.qif'))
+    expect(instance.size).to eq(3)
   end
 
   context 'given invalid data' do

--- a/spec/lib/reader_spec.rb
+++ b/spec/lib/reader_spec.rb
@@ -92,17 +92,17 @@ describe Qif::Reader do
     expect(@instance.size).to eq(3)
     expect(@instance.collect(&:amount)).to eq([-1010.0, -30020.0, 30.0])
   end
-  
+
   it 'should initialize with an io object' do
     @instance = Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'))
     expect(@instance.size).to eq(3)
   end
-  
+
   it 'should initialize with data in a string' do
     @instance = Qif::Reader.new(File.read('spec/fixtures/3_records_ddmmyyyy.qif'))
     expect(@instance.size).to eq(3)
   end
-  
+
   it 'should reject transactions whose date does not match the given date format' do
     @instance = Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'), 'mm/dd/yyyy')
     expect(@instance.size).to eq(2)

--- a/spec/lib/reader_spec.rb
+++ b/spec/lib/reader_spec.rb
@@ -103,9 +103,20 @@ describe Qif::Reader do
     expect(@instance.size).to eq(3)
   end
 
-  it 'should reject transactions whose date does not match the given date format' do
-    @instance = Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'), 'mm/dd/yyyy')
-    expect(@instance.size).to eq(2)
+  context 'given invalid data' do
+    let(:instance) { Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'), 'mm/dd/yyyy') }
+
+    it 'should reject transactions whose date does not match the given date format' do
+      expect(instance.size).to eq(2)
+    end
+
+    it 'should know about any errors' do
+      expect(instance.has_errors?).to be_truthy
+    end
+
+    it 'should provide access to any errors' do
+      expect(instance.errors).to eq([{ data: "29/12/2010", error: "invalid date" }])
+    end
   end
 
   context 'when reading splits' do

--- a/spec/lib/reader_spec.rb
+++ b/spec/lib/reader_spec.rb
@@ -2,28 +2,28 @@ require 'spec_helper'
 
 shared_examples_for "3 record files" do
   it 'should have 3 records' do
-    instance.size.should == 3
+    expect(instance.size).to eq(3)
   end
 
   it 'should have a debit of $10 on the 1st of January 2010' do
     transaction = instance.transactions.detect{|t| t.date == Date.new(2010, 1, 1)}
-    transaction.should_not be_nil
-    transaction.category.should == 'Debit'
-    transaction.amount.should == -10.0
+    expect(transaction).not_to be_nil
+    expect(transaction.category).to eq('Debit')
+    expect(transaction.amount).to eq(-10.0)
   end
 
   it 'should have a debit of $20 on the 1st of June 1020' do
     transaction = instance.transactions.detect{|t| t.date == Date.new(2010, 6, 1)}
-    transaction.should_not be_nil
-    transaction.category.should == 'Debit'
-    transaction.amount.should == -20.0
+    expect(transaction).not_to be_nil
+    expect(transaction.category).to eq('Debit')
+    expect(transaction.amount).to eq(-20.0)
   end
 
   it 'should have a credit of $30 on the 29th of December 2010' do
     transaction = instance.transactions.detect{|t| t.date == Date.new(2010, 12, 29)}
-    transaction.should_not be_nil
-    transaction.category.should == 'Credit'
-    transaction.amount.should == 30.0
+    expect(transaction).not_to be_nil
+    expect(transaction.category).to eq('Credit')
+    expect(transaction.amount).to eq(30.0)
   end
 
   describe '#each' do
@@ -32,7 +32,7 @@ shared_examples_for "3 record files" do
       instance.each do |t|
         transactions << t
       end
-      transactions.should == instance.transactions
+      expect(transactions).to eq(instance.transactions)
     end
   end
 end
@@ -68,44 +68,44 @@ describe Qif::Reader do
   describe '#guess_date_format' do
     it 'should guess the date format dd/mm/yyyy' do
       @instance = Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'))
-      @instance.guess_date_format.should == 'dd/mm/yyyy'
+      expect(@instance.guess_date_format).to eq('dd/mm/yyyy')
     end
 
     it 'should guess the date format mm/dd/yy' do
       @instance = Qif::Reader.new(open('spec/fixtures/3_records_mmddyy.qif'))
-      @instance.guess_date_format.should == 'mm/dd/yy'
+      expect(@instance.guess_date_format).to eq('mm/dd/yy')
     end
 
     it 'should fall back to best guess if the date are ambiguious' do
       @instance = Qif::Reader.new(open('spec/fixtures/quicken_non_investement_account.qif'))
-      @instance.guess_date_format.should == 'dd/mm/yy'
+      expect(@instance.guess_date_format).to eq('dd/mm/yy')
     end
 
     it 'should guess the date format d/m/yy' do
       @instance = Qif::Reader.new(open('spec/fixtures/3_records_dmyy.qif'))
-      @instance.guess_date_format.should == 'dd/mm/yy'
+      expect(@instance.guess_date_format).to eq('dd/mm/yy')
     end
   end
 
   it 'should parse amounts with comma separator too' do
     @instance = Qif::Reader.new(open('spec/fixtures/3_records_separator.qif'))
-    @instance.size.should == 3
-    @instance.collect(&:amount).should == [-1010.0, -30020.0, 30.0]
+    expect(@instance.size).to eq(3)
+    expect(@instance.collect(&:amount)).to eq([-1010.0, -30020.0, 30.0])
   end
   
   it 'should initialize with an io object' do
     @instance = Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'))
-    @instance.size.should == 3
+    expect(@instance.size).to eq(3)
   end
   
   it 'should initialize with data in a string' do
     @instance = Qif::Reader.new(File.read('spec/fixtures/3_records_ddmmyyyy.qif'))
-    @instance.size.should == 3
+    expect(@instance.size).to eq(3)
   end
   
   it 'should reject transactions whose date does not match the given date format' do
     @instance = Qif::Reader.new(open('spec/fixtures/3_records_ddmmyyyy.qif'), 'mm/dd/yyyy')
-    @instance.size.should == 2
+    expect(@instance.size).to eq(2)
   end
 
   context 'when reading splits' do

--- a/spec/lib/writer_spec.rb
+++ b/spec/lib/writer_spec.rb
@@ -6,12 +6,12 @@ describe Qif::Writer do
   let(:io) { StringIO.new(buffer) }
   let(:instance) { Qif::Writer.new(io) }
   let(:path) { "/tmp/test" }
-  
+
   describe '::open' do
     before do
       allow(File).to receive(:open).and_yield(io)
     end
-    
+
     it 'should yield a Qif::Writer' do
       ran = false
       Qif::Writer.open(path) do |writer|
@@ -20,19 +20,19 @@ describe Qif::Writer do
       end
       expect(ran).to eq true
     end
-    
+
     it 'should write the transactions' do
       date = Time.now
-      
+
       Qif::Writer.open(path) do |writer|
         writer << Qif::Transaction.new(:date => date, :amount => 10.0, :category => 'Credit')
       end
-      
+
       expect(buffer).to include('D%s' % date.strftime('%d/%m/%Y'))
       expect(buffer).to include('T10.0')
       expect(buffer).to include('LCredit')
     end
-    
+
     it 'should perform a File.open on the given path' do
       expect(File).to receive(:open).with(path, 'w')
       Qif::Writer.open(path) do |writer|
@@ -49,19 +49,19 @@ describe Qif::Writer do
       end
       expect(ran).to eq true
     end
-    
+
     it 'should write the transactions' do
       date = Time.now
-      
+
       Qif::Writer.new(io) do |writer|
         writer << Qif::Transaction.new(:date => date, :amount => 10.0, :category => 'Credit')
       end
-      
+
       expect(buffer).to include('D%s' % date.strftime('%d/%m/%Y'))
       expect(buffer).to include('T10.0')
       expect(buffer).to include('LCredit')
     end
-    
+
     it 'should perform a File.open on the given path' do
       expect(File).to receive(:open).with(path, 'w')
       Qif::Writer.open(path) do |writer|
@@ -76,16 +76,16 @@ describe Qif::Writer do
       instance.write
       expect(buffer).to include("!Type:Bank\n")
     end
-    
+
     it 'should write any pending transactions' do
       instance << Qif::Transaction.new(:date => date, :amount => 10.0, :category => 'Credit')
-      
+
       expect(buffer).not_to include('D%s' % date.strftime('%d/%m/%Y'))
       instance.write
       expect(buffer).to include('D%s' % date.strftime('%d/%m/%Y'))
     end
   end
-  
+
   describe '#close' do
     it 'should close the io stream' do
       expect(io).to receive(:close)

--- a/spec/lib/writer_spec.rb
+++ b/spec/lib/writer_spec.rb
@@ -9,16 +9,16 @@ describe Qif::Writer do
   
   describe '::open' do
     before do
-      File.stub(:open).and_yield io
+      allow(File).to receive(:open).and_yield(io)
     end
     
     it 'should yield a Qif::Writer' do
       ran = false
       Qif::Writer.open(path) do |writer|
         ran = true
-        writer.should be_a(Qif::Writer)
+        expect(writer).to be_a(Qif::Writer)
       end
-      ran.should eq true
+      expect(ran).to eq true
     end
     
     it 'should write the transactions' do
@@ -28,13 +28,13 @@ describe Qif::Writer do
         writer << Qif::Transaction.new(:date => date, :amount => 10.0, :category => 'Credit')
       end
       
-      buffer.should include('D%s' % date.strftime('%d/%m/%Y'))
-      buffer.should include('T10.0')
-      buffer.should include('LCredit')
+      expect(buffer).to include('D%s' % date.strftime('%d/%m/%Y'))
+      expect(buffer).to include('T10.0')
+      expect(buffer).to include('LCredit')
     end
     
     it 'should perform a File.open on the given path' do
-      File.should_receive(:open).with(path, 'w')
+      expect(File).to receive(:open).with(path, 'w')
       Qif::Writer.open(path) do |writer|
       end
     end
@@ -45,7 +45,7 @@ describe Qif::Writer do
       ran = false
       Qif::Writer.new(io) do |writer|
         ran = true
-        writer.should be_a(Qif::Writer)
+        expect(writer).to be_a(Qif::Writer)
       end
       expect(ran).to eq true
     end
@@ -57,13 +57,13 @@ describe Qif::Writer do
         writer << Qif::Transaction.new(:date => date, :amount => 10.0, :category => 'Credit')
       end
       
-      buffer.should include('D%s' % date.strftime('%d/%m/%Y'))
-      buffer.should include('T10.0')
-      buffer.should include('LCredit')
+      expect(buffer).to include('D%s' % date.strftime('%d/%m/%Y'))
+      expect(buffer).to include('T10.0')
+      expect(buffer).to include('LCredit')
     end
     
     it 'should perform a File.open on the given path' do
-      File.should_receive(:open).with(path, 'w')
+      expect(File).to receive(:open).with(path, 'w')
       Qif::Writer.open(path) do |writer|
       end
     end
@@ -74,21 +74,21 @@ describe Qif::Writer do
 
     it 'should write the header' do
       instance.write
-      buffer.should include("!Type:Bank\n")
+      expect(buffer).to include("!Type:Bank\n")
     end
     
     it 'should write any pending transactions' do
       instance << Qif::Transaction.new(:date => date, :amount => 10.0, :category => 'Credit')
       
-      buffer.should_not include('D%s' % date.strftime('%d/%m/%Y'))
+      expect(buffer).not_to include('D%s' % date.strftime('%d/%m/%Y'))
       instance.write
-      buffer.should include('D%s' % date.strftime('%d/%m/%Y'))
+      expect(buffer).to include('D%s' % date.strftime('%d/%m/%Y'))
     end
   end
   
   describe '#close' do
     it 'should close the io stream' do
-      io.should_receive(:close)
+      expect(io).to receive(:close)
       instance.close
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require File.dirname(__FILE__) + '/../lib/qif'
+require 'byebug'
 
 require_relative "support/shared/builder_method"


### PR DESCRIPTION
I addressed the RSpec deprecation issues and squashed a pet peeve of mine of avoiding rescuing exceptions with nil. My editor is pretty intolerant of tabs but I kept all such "corrections" in separate commits.

Thanks for your excellent work on this gem. You saved me quite a bit of time.
